### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Snoffleware.LLBLGen.Identity.Test/Snoffleware.LLBLGen.Identity.Test.csproj
+++ b/Snoffleware.LLBLGen.Identity.Test/Snoffleware.LLBLGen.Identity.Test.csproj
@@ -19,17 +19,17 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.6.1" />
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.6.1" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.7.2" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.7.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@timothyleerussell, I found an issue in the Snoffleware.LLBLGen.Identity.Test.csproj:

Packages Microsoft.Extensions.Identity.Stores v5.0.3, Microsoft.NET.Test.Sdk v16.8.3, MSTest.TestAdapter v2.1.2, coverlet.collector v3.0.2, SD.LLBLGen.Pro.DQE.SqlServer v5.6.1 and SD.LLBLGen.Pro.ORMSupportClasses v5.6.1 transitively introduce 127 dependencies into Snoffleware.LLBLGen.Identity’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Snoffleware-LLBLGen-Identity.html)), while Microsoft.Extensions.Identity.Stores v5.0.4, Microsoft.NET.Test.Sdk v16.9.1, MSTest.TestAdapter v2.2.1, coverlet.collector v3.0.3, SD.LLBLGen.Pro.DQE.SqlServer v5.7.2 and SD.LLBLGen.Pro.ORMSupportClasses v5.7.2 can only introduce 96 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Snoffleware-LLBLGen-Identity_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose